### PR TITLE
feature/mouse events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,6 +583,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 name = "lazybar"
 version = "0.2.1"
 dependencies = [
+ "aho-corasick",
  "anyhow",
  "cairo-rs",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 keywords = ["X11","WM","Linux","status-bar","i3"]
 
 [dependencies]
+aho-corasick = "1.1.3"
 anyhow = "1.0.86"
 cairo-rs = { version = "0.19.4", features = ["xcb"] }
 chrono = { version = "0.4.38", default-features = false, features = ["alloc", "clock"] }

--- a/src/attrs.rs
+++ b/src/attrs.rs
@@ -33,15 +33,15 @@ impl Attrs {
     ///
     /// Configuration options:
     ///
-    /// `fg: String`: Specify the foreground (usually text) color. All parsing
-    /// methods from [csscolorparser] are available.
+    /// - `fg: String`: Specify the foreground (usually text) color. All parsing
+    ///   methods from [csscolorparser] are available.
     ///
-    /// `bg: String`: Specify the background color. All parsing methods from
-    /// [csscolorparser] are available.
+    /// - `bg: String`: Specify the background color. All parsing methods from
+    ///   [csscolorparser] are available.
     ///
-    /// `font: String`: Specify the font to be used. This will be turned into a
-    /// [`pango::FontDescription`], so it's very configurable. Font family,
-    /// weight, size, and more can be specified.
+    /// - `font: String`: Specify the font to be used. This will be turned into
+    ///   a [`pango::FontDescription`], so it's very configurable. Font family,
+    ///   weight, size, and more can be specified.
     pub fn parse<S: std::hash::BuildHasher>(
         table: &mut HashMap<String, config::Value, S>,
         prefix: &str,

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, ops::BitAnd, rc::Rc};
+use std::{fmt::Debug, ops::BitAnd, rc::Rc, sync::Arc};
 
 use anyhow::Result;
 use csscolorparser::Color;
@@ -150,7 +150,7 @@ impl Panel {
 pub struct Bar {
     name: String,
     position: Position,
-    pub(crate) conn: xcb::Connection,
+    pub(crate) conn: Arc<xcb::Connection>,
     screen: i32,
     window: x::Window,
     surface: cairo::XCBSurface,
@@ -197,7 +197,7 @@ impl Bar {
         Ok(Self {
             name,
             position,
-            conn,
+            conn: Arc::new(conn),
             screen,
             window,
             surface,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,8 @@ pub mod builders {
     use tokio_stream::{StreamExt, StreamMap};
 
     use crate::{
-        Alignment, Attrs, Bar, Color, Margins, Panel, PanelConfig, Position,
+        x::XStream, Alignment, Attrs, Bar, Color, Margins, Panel, PanelConfig,
+        Position,
     };
     pub use crate::{PanelCommonBuilder, PanelCommonBuilderError};
 
@@ -282,30 +283,32 @@ pub mod builders {
             }
             bar.streams.insert(Alignment::Right, right_panels);
 
+            let mut x_stream = XStream::new(bar.conn.clone());
+
             task::spawn_local(async move {
-            loop {
-                tokio::select! {
-                    Ok(Some(event)) = async { bar.conn.poll_for_event() } => {
-                        if let Err(e) = bar.process_event(&event) {
-                            log::warn!("X event caused an error: {e}");
-                            // close when X server does
-                            // this could cause problems, maybe only exit under certain
-                            // circumstances?
-                            std::process::exit(0);
-                        }
-                    },
-                    Some((alignment, result)) = bar.streams.next() => {
-                        match result {
-                            (idx, Ok(draw_info)) => if let Err(e) = bar.update_panel(alignment, idx, draw_info) {
-                                log::warn!("Error updating {alignment} panel at index {idx}: {e}");
+                loop {
+                    tokio::select! {
+                        Some(Ok(event)) = x_stream.next() => {
+                            if let Err(e) = bar.process_event(&event) {
+                                log::warn!("X event caused an error: {e}");
+                                // close when X server does
+                                // this could cause problems, maybe only exit under certain
+                                // circumstances?
+                                std::process::exit(0);
                             }
-                            (idx, Err(e)) =>
-                                log::warn!("Error produced by {alignment} panel at index {idx:?}: {e}"),
-                        }
-                    },
+                        },
+                        Some((alignment, result)) = bar.streams.next() => {
+                            match result {
+                                (idx, Ok(draw_info)) => if let Err(e) = bar.update_panel(alignment, idx, draw_info) {
+                                    log::warn!("Error updating {alignment} panel at index {idx}: {e}");
+                                }
+                                (idx, Err(e)) =>
+                                    log::warn!("Error produced by {alignment} panel at index {idx:?}: {e}"),
+                            }
+                        },
+                    }
                 }
-            }
-        }).await?;
+            }).await?;
 
             Ok(())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ use std::{collections::HashMap, fmt::Display, pin::Pin, rc::Rc};
 
 use anyhow::Result;
 pub use attrs::Attrs;
-use bar::{Bar, Panel, PanelDrawInfo};
+use bar::{Bar, Event, Panel, PanelDrawInfo};
 pub use builders::BarConfig;
 use config::{Config, Value};
 pub use csscolorparser::Color;
@@ -100,7 +100,7 @@ pub trait PanelConfig {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)>;
+    ) -> Result<(PanelStream, Option<Sender<Event>>)>;
 }
 
 /// Describes where on the screen the bar should appear.

--- a/src/panels/battery.rs
+++ b/src/panels/battery.rs
@@ -7,8 +7,9 @@ use tokio::{sync::mpsc::Sender, time::interval};
 use tokio_stream::{wrappers::IntervalStream, StreamExt};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_string_from_config,
-    remove_uint_from_config, Attrs, PanelCommon, PanelConfig, PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_string_from_config, remove_uint_from_config, Attrs,
+    PanelCommon, PanelConfig, PanelStream,
 };
 
 /// Shows the current battery level.
@@ -158,7 +159,7 @@ impl PanelConfig for Battery {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         for attr in &mut self.common.attrs {
             attr.apply_to(&global_attrs);
         }

--- a/src/panels/clock.rs
+++ b/src/panels/clock.rs
@@ -20,8 +20,8 @@ use tokio::{
 use tokio_stream::{wrappers::ReceiverStream, Stream, StreamExt, StreamMap};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, Attrs, PanelCommon, PanelConfig,
-    PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, Attrs, PanelCommon, PanelConfig, PanelStream,
 };
 
 /// Defines options for a [`Clock`]'s precision.
@@ -143,13 +143,13 @@ impl<P: Precision + Clone> Clock<P> {
         )
     }
 
-    fn process_event(idx: Rc<Mutex<(usize, usize)>>, event: &'static str) {
+    fn process_event(idx: Rc<Mutex<(usize, usize)>>, event: Event) {
         match event {
-            "cycle" => {
+            Event::Action("cycle") => {
                 let mut idx = idx.lock().unwrap();
                 *idx = ((idx.0 + 1) % idx.1, idx.1);
             }
-            "cycle_back" => {
+            Event::Action("cycle_back") => {
                 let mut idx = idx.lock().unwrap();
                 *idx = ((idx.0 - 1 + idx.1) % idx.1, idx.1);
             }
@@ -195,7 +195,7 @@ where
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         for attr in &mut self.common.attrs {
             attr.apply_to(&global_attrs);
         }

--- a/src/panels/cpu.rs
+++ b/src/panels/cpu.rs
@@ -8,8 +8,9 @@ use tokio::{sync::mpsc::Sender, time::interval};
 use tokio_stream::{wrappers::IntervalStream, StreamExt};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_string_from_config,
-    remove_uint_from_config, Attrs, PanelCommon, PanelConfig, PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_string_from_config, remove_uint_from_config, Attrs,
+    PanelCommon, PanelConfig, PanelStream,
 };
 
 lazy_static! {
@@ -106,7 +107,7 @@ impl PanelConfig for Cpu {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         for attr in &mut self.common.attrs {
             attr.apply_to(&global_attrs);
         }

--- a/src/panels/cpu.rs
+++ b/src/panels/cpu.rs
@@ -37,7 +37,6 @@ impl Cpu {
         let load = read_current_load(self.path.as_str())?;
 
         let diff = load.total - self.last_load.total;
-        self.last_load = load;
 
         let percentage = (diff - (load.idle - self.last_load.idle)) as f64
             / diff as f64
@@ -45,6 +44,8 @@ impl Cpu {
 
         let text = self.common.formats[0]
             .replace("%percentage%", format!("{percentage:.0}").as_str());
+
+        self.last_load = load;
 
         draw_common(
             cr,

--- a/src/panels/custom.rs
+++ b/src/panels/custom.rs
@@ -16,8 +16,9 @@ use tokio::{
 use tokio_stream::{Stream, StreamExt};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_string_from_config,
-    remove_uint_from_config, Attrs, PanelCommon, PanelConfig, PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_string_from_config, remove_uint_from_config, Attrs,
+    PanelCommon, PanelConfig, PanelStream,
 };
 
 struct CustomStream {
@@ -151,7 +152,7 @@ impl PanelConfig for Custom {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         for attr in &mut self.common.attrs {
             attr.apply_to(&global_attrs);
         }

--- a/src/panels/fanotify.rs
+++ b/src/panels/fanotify.rs
@@ -20,8 +20,9 @@ use tokio::{
 use tokio_stream::{Stream, StreamExt};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_string_from_config, Attrs,
-    PanelCommon, PanelConfig, PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_string_from_config, Attrs, PanelCommon, PanelConfig,
+    PanelStream,
 };
 
 struct FanotifyStream {
@@ -140,7 +141,7 @@ impl PanelConfig for Fanotify {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         // FAN_REPORT_FID is required without CAP_SYS_ADMIN, but nix v0.29
         // doesn't know that it's real
         let init_flags = InitFlags::from_bits_retain(0x00000200);

--- a/src/panels/inotify.rs
+++ b/src/panels/inotify.rs
@@ -20,8 +20,9 @@ use tokio::{
 use tokio_stream::{Stream, StreamExt};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_string_from_config, Attrs,
-    PanelCommon, PanelConfig, PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_string_from_config, Attrs, PanelCommon, PanelConfig,
+    PanelStream,
 };
 
 struct InotifyStream {
@@ -138,7 +139,7 @@ impl PanelConfig for Inotify {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         let init_flags = InitFlags::empty();
         let inotify = inotify::Inotify::init(init_flags)?;
 

--- a/src/panels/memory.rs
+++ b/src/panels/memory.rs
@@ -9,8 +9,9 @@ use tokio::{sync::mpsc::Sender, time::interval};
 use tokio_stream::{wrappers::IntervalStream, StreamExt};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_string_from_config,
-    remove_uint_from_config, Attrs, PanelCommon, PanelConfig, PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_string_from_config, remove_uint_from_config, Attrs,
+    PanelCommon, PanelConfig, PanelStream,
 };
 
 lazy_static! {
@@ -208,7 +209,7 @@ impl PanelConfig for Memory {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         for attr in &mut self.common.attrs {
             attr.apply_to(&global_attrs);
         }

--- a/src/panels/network.rs
+++ b/src/panels/network.rs
@@ -18,8 +18,9 @@ use tokio::{sync::mpsc::Sender, time::interval};
 use tokio_stream::{wrappers::IntervalStream, StreamExt};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_string_from_config,
-    remove_uint_from_config, Attrs, PanelCommon, PanelConfig, PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_string_from_config, remove_uint_from_config, Attrs,
+    PanelCommon, PanelConfig, PanelStream,
 };
 
 #[repr(C)]
@@ -213,7 +214,7 @@ impl PanelConfig for Network {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         for attr in &mut self.common.attrs {
             attr.apply_to(&global_attrs);
         }

--- a/src/panels/ping.rs
+++ b/src/panels/ping.rs
@@ -20,9 +20,9 @@ use tokio::{
 use tokio_stream::{Stream, StreamExt};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_string_from_config,
-    remove_uint_from_config, Attrs, PanelCommon, PanelConfig, PanelStream,
-    Ramp,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_string_from_config, remove_uint_from_config, Attrs,
+    PanelCommon, PanelConfig, PanelStream, Ramp,
 };
 
 /// Displays the ping to a given address
@@ -159,7 +159,7 @@ impl PanelConfig for Ping {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         for attr in &mut self.common.attrs {
             attr.apply_to(&global_attrs);
         }

--- a/src/panels/separator.rs
+++ b/src/panels/separator.rs
@@ -5,7 +5,9 @@ use config::{Config, Value};
 use derive_builder::Builder;
 use tokio::sync::mpsc::Sender;
 
-use crate::{draw_common, Attrs, PanelCommon, PanelConfig, PanelStream};
+use crate::{
+    bar::Event, draw_common, Attrs, PanelCommon, PanelConfig, PanelStream,
+};
 
 /// Displays static text with [pango] markup.
 #[derive(Builder, Debug)]
@@ -49,7 +51,7 @@ impl PanelConfig for Separator {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         for attr in &mut self.common.attrs {
             attr.apply_to(&global_attrs);
         }

--- a/src/panels/temp.rs
+++ b/src/panels/temp.rs
@@ -6,8 +6,9 @@ use tokio::{sync::mpsc::Sender, time::interval};
 use tokio_stream::{wrappers::IntervalStream, StreamExt};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_uint_from_config, Attrs,
-    PanelCommon, PanelConfig, PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_uint_from_config, Attrs, PanelCommon, PanelConfig,
+    PanelStream,
 };
 
 /// Displays the temperature of a provided thermal zone.
@@ -96,7 +97,7 @@ impl PanelConfig for Temp {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         for attr in &mut self.common.attrs {
             attr.apply_to(&global_attrs);
         }

--- a/src/panels/xwindow.rs
+++ b/src/panels/xwindow.rs
@@ -17,8 +17,10 @@ use tokio_stream::{Stream, StreamExt};
 use xcb::{x, XidNew};
 
 use crate::{
-    bar::PanelDrawInfo, draw_common, remove_string_from_config,
-    x::intern_named_atom, Attrs, PanelCommon, PanelConfig, PanelStream,
+    bar::{Event, PanelDrawInfo},
+    draw_common, remove_string_from_config,
+    x::intern_named_atom,
+    Attrs, PanelCommon, PanelConfig, PanelStream,
 };
 
 struct XStream {
@@ -206,7 +208,7 @@ impl PanelConfig for XWindow {
         cr: Rc<cairo::Context>,
         global_attrs: Attrs,
         _height: i32,
-    ) -> Result<(PanelStream, Option<Sender<&'static str>>)> {
+    ) -> Result<(PanelStream, Option<Sender<Event>>)> {
         let name_atom = intern_named_atom(&self.conn, b"_NET_WM_NAME")?;
         let window_atom = intern_named_atom(&self.conn, b"_NET_ACTIVE_WINDOW")?;
         let utf8_atom = intern_named_atom(&self.conn, b"UTF8_STRING")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -36,7 +36,10 @@ lazy_static! {
                 .required(true),
             )
             .build()
-            .unwrap()
+            .unwrap_or_else(|e| {
+                log::error!("Error parsing config file: {e}");
+                std::process::exit(101);
+            })
     };
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,6 +44,66 @@ pub fn draw_common(
     ))
 }
 
+/// A map from mouse buttons to panel events
+#[derive(Debug, Clone, Default, Builder)]
+pub struct Actions {
+    /// The event that should be run when the panel is left-clicked
+    #[builder(default = "String::new()")]
+    pub left: String,
+    /// The event that should be run when the panel is right-clicked
+    #[builder(default = "String::new()")]
+    pub right: String,
+    /// The event that should be run when the panel is middle-clicked
+    #[builder(default = "String::new()")]
+    pub middle: String,
+    /// The event that should be run when the panel is scrolled up
+    #[builder(default = "String::new()")]
+    pub up: String,
+    /// The event that should be run when the panel is scrolled down
+    #[builder(default = "String::new()")]
+    pub down: String,
+}
+
+impl Actions {
+    /// Attempts to parse an instance of this type from a subset of tthe global
+    /// [`Config`][config::Config].
+    ///
+    /// Configuration options:
+    /// - `click_left`: The name of the event to run when the panel is
+    ///   left-clicked.
+    /// - `click_right`: The name of the event to run when the panel is
+    ///   right-clicked.
+    /// - `click_middle`: The name of the event to run when the panel is
+    ///   middle-clicked.
+    /// - `scroll_up`: The name of the event to run when the panel is scrolled
+    ///   up.
+    /// - `scroll_down`: The name of the event to run when the panel is scrolled
+    ///   down.
+    pub fn parse<S: std::hash::BuildHasher>(
+        table: &mut HashMap<String, Value, S>,
+    ) -> Result<Self> {
+        let mut builder = ActionsBuilder::default();
+
+        if let Some(left) = remove_string_from_config("click_left", table) {
+            builder.left(left);
+        }
+        if let Some(right) = remove_string_from_config("click_right", table) {
+            builder.right(right);
+        }
+        if let Some(middle) = remove_string_from_config("click_middle", table) {
+            builder.middle(middle);
+        }
+        if let Some(up) = remove_string_from_config("scroll_up", table) {
+            builder.up(up);
+        }
+        if let Some(down) = remove_string_from_config("scroll_down", table) {
+            builder.down(down);
+        }
+
+        Ok(builder.build()?)
+    }
+}
+
 /// The common part of most [`PanelConfigs`][crate::PanelConfig]. Stores format
 /// strings, [`Attrs`], and [`Dependence`]
 #[derive(Debug, Clone, Builder)]
@@ -56,6 +116,9 @@ pub struct PanelCommon {
     pub dependence: Dependence,
     /// The instances of [`Attrs`] used by the panel
     pub attrs: Vec<Attrs>,
+    /// The events that should be run on mouse events
+    // #[builder(default)]
+    pub actions: Actions,
 }
 
 impl PanelCommon {
@@ -66,7 +129,7 @@ impl PanelCommon {
     /// Format strings should be specified as `format{suffix} = "value"`.
     /// Dependence should be specified as `dependence = "value"`, where value is
     /// a valid variant of [`Dependence`].
-    /// See [`Attrs::parse`] for more parsing details.
+    /// See [`Attrs::parse`] and [`Actions::parse`] for more parsing details.
     pub fn parse<S: std::hash::BuildHasher>(
         table: &mut HashMap<String, Value, S>,
         format_suffixes: &[&'static str],
@@ -107,6 +170,8 @@ impl PanelCommon {
                 .map(|p| Attrs::parse(table, p))
                 .collect(),
         );
+
+        builder.actions(Actions::parse(table)?);
 
         Ok(builder.build()?)
     }
@@ -156,6 +221,8 @@ impl PanelCommon {
                 .map(|p| Attrs::parse(table, p))
                 .collect(),
         );
+
+        builder.actions(Actions::parse(table)?);
 
         Ok(builder.build()?)
     }


### PR DESCRIPTION
Add support for mouse events for several built-in panels, along with infrastructure for future panels and ipc.

- **implement xstream for the bar to integrate with tokio better**
- **change panel channels to send mouse events and action strings**
- **clock, mpd, pulseaudio, xworkspaces: add events and support for mouse interaction**
